### PR TITLE
Prefix theme classnames with hyphens

### DIFF
--- a/prototype/app/index.html
+++ b/prototype/app/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
     <!-- BEGIN UNITY BAR HTML -->
-    <header class="pwd-unity-bar pwdub-theme-blue">
+    <header class="pwd-unity-bar -pwdub-theme-blue">
         <div class="app-switcher">
             <h1 class="appname">App Name</h1>
             <button class="toggle" type="button" title="More stormwater apps" name="app-switcher-toggle" aria-label="More stormwater apps">

--- a/prototype/app/js/main.js
+++ b/prototype/app/js/main.js
@@ -73,8 +73,8 @@ $(function() {
     // THEME SWITCHER
     $('.demo-panel > .themes > button').on('click', function() {
         $('.pwd-unity-bar')
-            .removeClass('pwdub-theme-blue pwdub-theme-white pwdub-theme-internal')
-            .addClass('pwdub-theme-' + $(this).attr('name'));
+            .removeClass('-pwdub-theme-blue -pwdub-theme-white -pwdub-theme-internal')
+            .addClass('-pwdub-theme-' + $(this).attr('name'));
     });
 
     // APP SWITCHER

--- a/prototype/app/sass/05_basics/_themes.scss
+++ b/prototype/app/sass/05_basics/_themes.scss
@@ -1,4 +1,4 @@
-.pwd-unity-bar.pwdub-theme-white {
+.pwd-unity-bar.-pwdub-theme-white {
     background-color: $pwdub-white;
     color: $pwdub-blue;
 
@@ -28,7 +28,7 @@
     }
 }
 
-.pwd-unity-bar.pwdub-theme-blue {
+.pwd-unity-bar.-pwdub-theme-blue {
     background-color: $pwdub-blue;
     color: $pwdub-white;
 
@@ -63,7 +63,7 @@
     }
 }
 
-.pwd-unity-bar.pwdub-theme-internal {
+.pwd-unity-bar.-pwdub-theme-internal {
     background-color: $pwdub-purple;
     color: $pwdub-white;
 

--- a/prototype/app/sass/pwd-unity-bar.scss
+++ b/prototype/app/sass/pwd-unity-bar.scss
@@ -108,7 +108,7 @@ $pwdub-z-index: 10000 !default;
     }
 }
 
-.pwd-unity-bar.pwdub-theme-white {
+.pwd-unity-bar.-pwdub-theme-white {
     background-color: $pwdub-white;
     color: $pwdub-blue;
 
@@ -138,7 +138,7 @@ $pwdub-z-index: 10000 !default;
     }
 }
 
-.pwd-unity-bar.pwdub-theme-blue {
+.pwd-unity-bar.-pwdub-theme-blue {
     background-color: $pwdub-blue;
     color: $pwdub-white;
 
@@ -173,7 +173,7 @@ $pwdub-z-index: 10000 !default;
     }
 }
 
-.pwd-unity-bar.pwdub-theme-internal {
+.pwd-unity-bar.-pwdub-theme-internal {
     background-color: $pwdub-purple;
     color: $pwdub-white;
 


### PR DESCRIPTION
The theme classnames are variants, which should be hyphen prefixed per rscss guidelines. Somehow I neglected to do this and then had dreams about it last night. Really.