### PR TITLE
Add signOutHandler for authenticated actions

### DIFF
--- a/src/js/AppActions.jsx
+++ b/src/js/AppActions.jsx
@@ -38,6 +38,7 @@ export default function AppActions({
     hasSettings,
     settingsUrl,
     settingsHandler,
+    signOutHandler,
     customMenuOptions,
     searchBoxExpanded,
     expandSearchBox,
@@ -106,6 +107,7 @@ export default function AppActions({
             closeAuthenticatedActions={closeAuthenticatedActions}
             hasSettings={hasSettings}
             settingsHandler={settingsHandler}
+            signOutHandler={signOutHandler}
             settingsUrl={settingsUrl}
             customMenuOptions={customMenuOptions}
             closeAllElements={closeAllElements}
@@ -139,6 +141,7 @@ AppActions.propTypes = {
     hasSettings: bool,
     settingsUrl: string,
     settingsHandler: func,
+    signOutHandler: func,
     customMenuOptions: arrayOf(customMenuOptionPropType),
     searchBoxExpanded: bool,
     expandSearchBox: func,

--- a/src/js/AuthenticatedActionsMenu.jsx
+++ b/src/js/AuthenticatedActionsMenu.jsx
@@ -9,6 +9,7 @@ export default function AuthenticatedActionsMenu({
     hasSettings,
     settingsUrl,
     settingsHandler,
+    signOutHandler,
     customMenuOptions,
     authenticatedActionsOpen,
     openAuthenticatedActions,
@@ -88,7 +89,7 @@ export default function AuthenticatedActionsMenu({
                     <a
                         className="link"
                         tabIndex={tabIndex}
-                        href=""
+                        onClick={signOutHandler || null}
                     >
                         Sign out
                     </a>
@@ -101,6 +102,7 @@ export default function AuthenticatedActionsMenu({
 AuthenticatedActionsMenu.propTypes = {
     hasSettings: bool,
     settingsHandler: func,
+    signOutHandler: func,
     settingsUrl: string,
     customMenuOptions: arrayOf(customMenuOptionPropType),
     authenticatedActionsOpen: bool.isRequired,

--- a/src/js/UnityBar.jsx
+++ b/src/js/UnityBar.jsx
@@ -107,6 +107,7 @@ class UnityBar extends Component {
             hasSettings,
             settingsUrl,
             settingsHandler,
+            signOutHandler,
             customMenuOptions,
         } = this.props;
 
@@ -157,6 +158,13 @@ class UnityBar extends Component {
             }
         };
 
+        const wrappedSignOutHandler = () => {
+            if (signOutHandler) {
+                this.closeAllElements();
+                signOutHandler();
+            }
+        };
+
         return (
             <header className={`pwd-unity-bar ${unityBarTheme}`}>
                 <AppSwitcher
@@ -181,6 +189,7 @@ class UnityBar extends Component {
                     hasSettings={hasSettings}
                     settingsUrl={settingsUrl}
                     settingsHandler={wrappedSettingsHandler}
+                    signOutHandler={wrappedSignOutHandler}
                     customMenuOptions={customMenuOptions}
                     searchBoxExpanded={searchBoxExpanded}
                     expandSearchBox={this.expandSearchBox}
@@ -211,6 +220,7 @@ UnityBar.propTypes = {
     hasSettings: bool,
     settingsUrl: string,
     settingsHandler: func,
+    signOutHandler: func,
     customMenuOptions: arrayOf(customMenuOptionPropType),
 };
 
@@ -224,6 +234,9 @@ UnityBar.defaultProps = {
     hasHelpAction: true,
     authenticated: false,
     hasSettings: false,
+    signOutHandler() {
+        window.console.log('You signed out!');
+    },
 };
 
 export default onClickOutside(UnityBar);

--- a/src/sass/06_components/_additional-actions.scss
+++ b/src/sass/06_components/_additional-actions.scss
@@ -65,6 +65,7 @@
 
         > .listitem > .link {
             @include delinkify($pwdub-white);
+            cursor: pointer;
         }
     }
 }


### PR DESCRIPTION
## Overview

This PR adjusts the actions menu to accept a `signOutHandler` function which gets passed in from the app. I set the default action to just log "You signed out", but that'll be over-ridden when an app passes in an action.

Connects https://github.com/azavea/epa-star/pull/235

### Demo

![signouthandler](https://user-images.githubusercontent.com/4165523/31023148-f8a7689c-a508-11e7-8510-859a500c2c7a.gif)

## Testing Instructions
- get this branch, then `npm install` and `npm start`
- visit `localhost:7777`, then click the sign out action in the menu and verify that you see the action logging to the console
