### PR TITLE
Add and use babel-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-loader": "7.1.2",
     "babel-plugin-transform-runtime": "6.23.0",
     "babel-plugin-transform-class-properties": "6.24.1",
+    "babel-polyfill": "6.26.0",
     "babel-preset-es2015": "6.24.1",
     "babel-preset-react": "6.24.1",
     "babel-preset-react-hmre": "1.1.1",

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -3,7 +3,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
     entry: {
-        app: './Demo.jsx',
+        app: ['babel-polyfill', './Demo.jsx'],
         vendor: [
             'react',
             'react-dom',


### PR DESCRIPTION
## Overview

This PR adds `babel-polyfill` to ensure the development version of the app works on IE11.

Connects #12 

### Notes

As of now the app only has a webpack.dev.config setup and not a production config.

For EPA STAR we dropped the full source code into the repo -- and that project's webpack setup had run `babel-polyfill` over the code here to paper over `Object.values` et al. We've tended toward wanting to make this `npm install`able, and I think at that point whatever other project would handle `Object.values` stuff similarly.

## Testing Instructions
- get this branch, then `npm install` and `npm start`
- use FF, Chrome, Safari, and IE 11 to visit the app on localhost:7777, verifying that it loads and works in each