### PR TITLE
Add .travis.yml file and project scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js: 6.11.4
+
+script:
+    - ./scripts/cibuild

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PWD Unity Bar
 
+[![Build Status](https://travis-ci.org/azavea/pwd-unitybar.svg?branch=develop)](https://travis-ci.org/azavea/pwd-unitybar)
+
 Unified header React component for PWD Stormwater web apps.
 
 ### Requirements
@@ -11,16 +13,15 @@ Unified header React component for PWD Stormwater web apps.
 Install required dependencies by running:
 
 ```sh
-npm install
+./scripts/setup
 ```
 
 #### Development
 
 Run a demo version via webpack-dev-server using:
 
-
 ```sh
-npm start
+./scripts/server
 ```
 
 This will build and server the app on port 7777.
@@ -30,3 +31,25 @@ This will build and server the app on port 7777.
 | Service           | Port                            |
 | ----------------- | ------------------------------- |
 | PWD UnityBar demo | [`7777`](http://localhost:7777) |
+
+### Testing
+
+`./scripts/test`
+
+### Linting
+
+Run ESLint by running:
+
+```sh
+./scripts/lint
+```
+
+### Scripts
+
+| Name | Description |
+| --- | --- |
+| `cibuild` | Build project and run linter and tests on TravisCI |
+| `lint` | Run ESLint |
+| `server` | Start webpack-dev-server on port 7777 |
+| `setup` | Set up project for development |
+| `test` | Run tests |

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "src/js/UnityBar.jsx",
   "scripts": {
     "start": "node_modules/.bin/webpack-dev-server --config webpack.dev.config.js --progress --colors --host 0.0.0.0 --port 7777",
+    "lint": "node_modules/.bin/eslint src/js/**",
     "test": "echo \"Error: no test specified\" && exit 1",
     "postinstall": "npm rebuild node-sass --quiet --force"
   },

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -ex
+
+function usage() {
+    echo -n \
+    "Usage: $(basename "$0")
+Build application for TravisCI.
+"
+}
+
+function cibuild() {
+    ./scripts/setup
+    ./scripts/lint
+    ./scripts/test
+    ./scripts/test --git
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        cibuild
+    fi
+fi

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -ex
+
+npm run lint

--- a/scripts/server
+++ b/scripts/server
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -ex
+
+npm start

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -ex
+
+npm install

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -ex
+
+function usage() {
+    echo -n "Usage: $(basename "$0") [OPTION]
+
+Run tests.
+Options:
+    -h --help       Display this help text
+    --git           Check git commit titles
+"
+}
+
+function app_tests() {
+    # TODO: Run tests
+    true;
+}
+
+function git_tests() {
+    # Fail build if any commit title contains these words
+    if git log --oneline | grep -wiE "fixup|squash|wip"; then
+        echo "ERROR: Please squash all changes before merging."
+        exit 1
+    fi
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    case "${1:-}" in
+        -h|--help) usage ;;
+        --git)     git_tests ;;
+        *)         app_tests ;;
+    esac
+fi


### PR DESCRIPTION
## Overview

This PR adds a .travis.yml file to build the project on TravisCI, along with some standard project scripts to wrap the npm stuff which was here before. I added setup, server, test, lint, and cibuild scripts; each does what you'd expect -- although cibuild is currently only building the project on Travis, not creating any staging artifact.

Connects #10 
Connects #15

### Demo

<img width="699" alt="screen shot 2017-11-15 at 4 58 16 pm" src="https://user-images.githubusercontent.com/4165523/32862469-353fdedc-ca26-11e7-8967-e94dcb50c0f2.png">

### Notes

I re-enabled the previously present-in-the-test-script-but-not-usually-enabled `./scripts/test --git` option which is `false` if a git commit includes any of the following words: "fixup", "wip", "squash".

## Testing Instructions
- get this branch, then rm your node_modules dir and run `./scripts/setup` to confirm it builds
- run `./scripts/lint` to confirm that it lints
- run `./scripts/test` to confirm that it runs the git test
- run `./scripts/server` to confirm that it starts webpack-dev-server
- restart this build https://travis-ci.org/azavea/pwd-unitybar/builds/302715024 and verify that it runs cibuild and passes
