### PR TITLE
UI fixes

### DIFF
--- a/src/sass/01_settings/_color.scss
+++ b/src/sass/01_settings/_color.scss
@@ -4,6 +4,7 @@ $pwdub-lt-gray: #939393;
 $pwdub-v-lt-gray: #e6e6e6;
 $pwdub-blue: #0078c8;
 $pwdub-purple: #001a70;
+$pwdub-lt-purple: #7474C1;
 $pwdub-active: #00b5e2;
 $pwdub-background-color: $pwdub-blue !default;
 $pwdub-foreground-color: $pwdub-white !default;

--- a/src/sass/02_tools/_mixins.scss
+++ b/src/sass/02_tools/_mixins.scss
@@ -11,6 +11,7 @@
     padding: 0;
     vertical-align: middle;
     white-space: normal;
+    border-radius: 0;
     background: none;
     line-height: 1;
     appearance: none;

--- a/src/sass/05_basics/_themes.scss
+++ b/src/sass/05_basics/_themes.scss
@@ -99,4 +99,19 @@
             background-color: $pwdub-purple;
         }
     }
+
+    .app-switcher.-on {
+        > .toggle,
+        > .app-switcher-menu > .menu-header,
+        > .app-switcher-menu > .more-resources {
+            background-color: $pwdub-lt-purple;
+        }
+    }
+
+    .additional-actions.-on {
+        > .toggle,
+        > .actions-menu {
+            background-color: $pwdub-lt-purple;
+        }
+    }
 }

--- a/src/sass/06_components/_additional-actions.scss
+++ b/src/sass/06_components/_additional-actions.scss
@@ -11,11 +11,16 @@
         display: block;
         align-self: stretch;
         width: $pwdub-app-switcher-gutter;
+        outline: 0;
         cursor: pointer;
 
         > .icon {
             width: 24px;
             height: 18px;
+        }
+
+        &:focus > .icon {
+            outline: rgba($pwdub-v-lt-gray, .6) dotted 1px;
         }
 
         &:hover {

--- a/src/sass/06_components/_additional-actions.scss
+++ b/src/sass/06_components/_additional-actions.scss
@@ -32,6 +32,7 @@
         position: absolute;
         top: 100%;
         right: 0;
+        min-width: 132px;  // Tries to round to whole pixel to avoid rendering artifact in IE11.
         margin: 0;
         padding: 8px 16px;
         background-color: $pwdub-active;

--- a/src/sass/06_components/_app-actions.scss
+++ b/src/sass/06_components/_app-actions.scss
@@ -53,20 +53,17 @@
 
     > .link,
     > .additional-actions {
-        @include invisible;
+        @include remove;
     }
 
     > .search-form {
         position: absolute;
         top: calc(50% - 19px);
         right: 0;
-        left: 0;
-        flex-basis: 90%;
         width: 90%;
         z-index: 2;
 
         @include mobile {
-            flex-basis: 100%;
             width: 100%;
         }
     }

--- a/src/sass/06_components/_app-switcher.scss
+++ b/src/sass/06_components/_app-switcher.scss
@@ -25,6 +25,7 @@
         width: $pwdub-app-switcher-gutter;
         margin-right: 8px;
         cursor: pointer;
+        outline: 0;
         z-index: 11;
 
         > .icon {
@@ -34,6 +35,10 @@
             &.-back {
                 @include remove;
             }
+        }
+
+        &:focus > .icon {
+            outline: rgba($pwdub-v-lt-gray, .6) dotted 1px;
         }
 
         &:hover {

--- a/src/sass/06_components/_search-form.scss
+++ b/src/sass/06_components/_search-form.scss
@@ -31,6 +31,7 @@
     }
 
     > .field {
+        appearance: none;
         flex: auto;
         min-width: 100px;
         height: 38px;

--- a/src/sass/06_components/_search-form.scss
+++ b/src/sass/06_components/_search-form.scss
@@ -31,7 +31,7 @@
     }
 
     > .field {
-        width: 100%;
+        flex: auto;
         min-width: 100px;
         height: 38px;
         padding-right: 8px;
@@ -48,8 +48,8 @@
     }
 
     > .action {
-        @include remove;
         @include debuttonify;
+        display: none;
         height: 34px;
         padding: 0 8px;
         border: 2px solid $pwdub-white;
@@ -61,7 +61,7 @@
     }
 
     > .field:focus + .action {
-        @include restore;
+        display: block;
     }
 }
 

--- a/src/sass/07_layouts/_pwd-unity-bar.scss
+++ b/src/sass/07_layouts/_pwd-unity-bar.scss
@@ -12,7 +12,7 @@
     z-index: $pwdub-z-index;
 
     > .app-switcher {
-        flex: 0 1 calc((100% - 85px)/2);
+        width: calc((100% - 85px)/2);
     }
 
     > .logo {
@@ -27,6 +27,6 @@
     }
 
     > .app-actions {
-        flex: 0 1 calc((100% - 85px)/2);
+        width: calc((100% - 85px)/2);
     }
 }


### PR DESCRIPTION
## Overview

This PR addresses some UI issues across browsers:

- `<button>` outline artifacts in the left and right menu toggles (#20)
- Safari search field styling issues (#20; requires additional work in #33)
- IE11 search field layout issues (#19)

And one visual issue:
- Revisit menu color in internal mode (#31)

Connects #19, #20, #31

### Demo

![image](https://user-images.githubusercontent.com/128699/34882906-fb735110-f785-11e7-9759-91dbaee884e4.png)

### Notes

For the button outline issue reported in #20, I removed the default outline for those buttons and gave a subtle outline to the child icon when the button has focus (see screenshot above).

Re the awkward search field styling in Safari reported in #20, it turns out overriding the default styles of `<input type="search">` in desktop Safari requires setting `-webkit-appearance: none;`. This PR uses the unprefixed `appearance: none;` but it's not getting automatically prefixed with `-webkit`. It looks like webpack isn't using `postcss-loader`, which includes `autoprefixer`. I've created issue #33 to address that.

## Testing Instructions

* `pull`, `server`, `http://localhost:7777`
* All browsers: Confirm app-switcher and actions-menu buttons don't have outline artifacts when focused, and do have the new icon outline (see screenshot above).
* IE11: Confirm search field layout is reasonable.
* Safari: Open inspector and manually add `-webkit-` prefix to the search field's `appearance` property. Confirm the search field looks reasonable.
* Open inspector and change `header.pwd-unity-bar` from `.-pwdub-theme-blue` to `-pwdub-theme-internal`. Confirm the menus use the colors in the screenshot above.
