### PR TITLE
Make custom dropdown option style conform with other options

### DIFF
--- a/src/js/AuthenticatedActionsMenu.jsx
+++ b/src/js/AuthenticatedActionsMenu.jsx
@@ -49,13 +49,13 @@ export default function AuthenticatedActionsMenu({
                 role="menuitem"
                 key={i}
             >
-                <button
+                <a
                     className="link"
                     tabIndex={tabIndex}
                     onClick={onClickHandler}
                 >
                     {name}
-                </button>
+                </a>
             </li>)) : null;
 
     const authenticatedActionsOpenCSSClass = authenticatedActionsOpen ? '-on' : '';


### PR DESCRIPTION
## Overview

This PR fixes a bug I noticed while working on CSV exports whereby new custom menu options would display in style out of sync with the existing options.

Connects #37

### Demo

![screen shot 2018-04-13 at 3 47 28 pm](https://user-images.githubusercontent.com/4165523/38754964-fe812f6e-3f31-11e8-9978-c20cb756bad3.png)

## Testing Instructions
- get this branch then `./scripts/setup` and `./scripts/server`
- apply this patch:

[0001-Test-actions-menu-style-change.patch.txt](https://github.com/azavea/pwd-unitybar/files/1908735/0001-Test-actions-menu-style-change.patch.txt)

- visit 7777 and open the options menu and verify that the export csv link works and that it's styled to match the other menu items