### PR TITLE
Left-align items in additional actions menu

### DIFF
--- a/src/sass/06_components/_additional-actions.scss
+++ b/src/sass/06_components/_additional-actions.scss
@@ -42,7 +42,6 @@
         padding: 8px 16px;
         background-color: $pwdub-active;
         list-style: none;
-        text-align: right;
         box-shadow: -10px 10px 20px rgba($pwdub-black, 0.2);
 
         @include mobile {


### PR DESCRIPTION
## Overview

The items in the additional actions menu were awkwardly right-aligned. This fixes that.

### Demo

#### BEFORE

![screen shot 2018-04-24 at 3 04 33 pm](https://user-images.githubusercontent.com/128699/39208417-f04cf462-47d0-11e8-8f6c-fce94e4aaf37.png)

#### AFTER

![screen shot 2018-04-24 at 3 04 42 pm](https://user-images.githubusercontent.com/128699/39208418-f05e30d8-47d0-11e8-9ace-7e0fd86ccc73.png)


## Testing Instructions

* `./scripts/server`
* http://localhost:7777/
* Click the additional actions menu (ie, the down arrow on the right side)
* Use dev tools to artificially make one of the menu items sufficiently longer than the other
* Confirm the items are left-aligned
