### PR TITLE
Adjust app switcher text

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -29,8 +29,8 @@ export const customMenuOptionPropType = shape({
 });
 
 export const PARCEL_VIEWER = 'Parcel Viewer';
-export const RETROFIT_MAP = 'Stormwater Connect Map';
-export const CREDITS_EXPLORER = 'Stormwater Credits Explorer';
+export const RETROFIT_MAP = 'Stormwater Connect';
+export const CREDITS_EXPLORER = 'Credits Explorer';
 export const RETROFIT_CAMPAIGN = 'Stormwater Connect';
 
 export const pwdAppConfig = [
@@ -38,13 +38,13 @@ export const pwdAppConfig = [
         appCSSClass: '-all-properties',
         appHeading: 'For all properties',
         appName: PARCEL_VIEWER,
-        appDescription: `Information about your property, water account,
-            and stormwater billing charges.`,
+        appDescription: `Information about your property and the stormwater
+            charge on your bill.`,
         appUrl: '',
     },
     {
         appCSSClass: '-retrofit-developers',
-        appHeading: 'For stormwater infrastructure developers',
+        appHeading: 'For stormwater management vendors',
         appName: RETROFIT_MAP,
         appDescription: `Find commercial, industrial, and multifamily
             properties interested in a stormwater retrofit project.`,
@@ -54,8 +54,8 @@ export const pwdAppConfig = [
         appCSSClass: '-retrofit-properties',
         appHeading: 'For commercial, industrial, and multifamily properties',
         appName: CREDITS_EXPLORER,
-        appDescription: `See how much you can save by retrofitting stormwater
-            management infrastructure into your property.`,
+        appDescription: `See how much you can save by installing a stormwater
+            retrofit project.`,
         appUrl: '',
         secondAppName: RETROFIT_CAMPAIGN,
         secondAppDescription: `Learn how a grant from the Philadelphia Water


### PR DESCRIPTION
## Overview

This PR makes some requested text changes to the App Switcher

Connects https://github.com/azavea/pwd-garp/issues/760

### Demo

<img width="602" alt="screen shot 2018-07-19 at 5 00 46 pm" src="https://user-images.githubusercontent.com/4165523/42969872-99417cf4-8b75-11e8-8457-06e4d468e025.png">

### Notes

There's one additional app option which is shown by default for the marketing page, but we do not have it displayed in GARP so it doesn't need to be updated here yet.

## Testing Instructions

- get this branch, then `./scripts/server` and verify that the app switcher text matches what's described in https://github.com/azavea/pwd-garp/issues/760 "Property Owner Transition Pages.pdf" -- with the exception of the PV2.0 link stuff