### PR TITLE
Open app switcher links in new tabs

### DIFF
--- a/src/js/AppSummary.jsx
+++ b/src/js/AppSummary.jsx
@@ -24,6 +24,8 @@ export default function AppSummary({
                     className={`link ${currentLinkCSSClass}`}
                     tabIndex={tabIndex}
                     href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
                 >
                     {name}
                 </a>

--- a/src/js/AppSwitcher.jsx
+++ b/src/js/AppSwitcher.jsx
@@ -91,6 +91,8 @@ export default function AppSwitcher({
                         className="link"
                         tabIndex={tabIndex}
                         href="http://www.phila.gov/water/wu/stormwater/"
+                        target="_blank"
+                        rel="noopener noreferrer"
                     >
                         More PWD stormwater resources ➔
                     </a>


### PR DESCRIPTION
## Overview

This PR updates the app switcher links to have them open in new tabs 

Connects https://github.com/azavea/pwd-garp/pull/779

## Testing Instructions

- get this branch, then `./scripts/setup` and `./scripts/server`
- visit localhost:7777 and open the app switcher, then verify that the links included therein open in new tabs