### PR TITLE
A11y: Improve color contrast

### DIFF
--- a/src/sass/01_settings/_color.scss
+++ b/src/sass/01_settings/_color.scss
@@ -5,7 +5,6 @@ $pwdub-v-lt-gray: #e6e6e6;
 $pwdub-blue: #0078c8;
 $pwdub-purple: #001a70;
 $pwdub-lt-purple: #7474C1;
-$pwdub-active: #00b5e2;
 $pwdub-background-color: $pwdub-blue !default;
 $pwdub-foreground-color: $pwdub-white !default;
 $pwdub-action-hover-background-color: rgba($pwdub-black, .1);

--- a/src/sass/06_components/_additional-actions.scss
+++ b/src/sass/06_components/_additional-actions.scss
@@ -40,7 +40,7 @@
         min-width: 132px;  // Tries to round to whole pixel to avoid rendering artifact in IE11.
         margin: 0;
         padding: 8px 16px;
-        background-color: $pwdub-active;
+        background-color: $pwdub-blue;
         list-style: none;
         box-shadow: -10px 10px 20px rgba($pwdub-black, 0.2);
 
@@ -77,7 +77,7 @@
 
 .pwd-unity-bar .additional-actions.-on {
     > .toggle {
-        background-color: $pwdub-active;
+        background-color: $pwdub-blue;
 
         > .icon,
         > .icon > use > svg {

--- a/src/sass/06_components/_app-switcher-menu.scss
+++ b/src/sass/06_components/_app-switcher-menu.scss
@@ -24,7 +24,7 @@
         width: 50%;
         height: $pwdub-app-switcher-gutter;
         padding-left: $pwdub-app-switcher-gutter;
-        background-color: $pwdub-active;
+        background-color: $pwdub-blue;
 
         @include tablet {
             justify-content: center;
@@ -41,7 +41,7 @@
             @include responsive(800px) {
                 font-size: 16px;
             }
-            
+
             @include mobile {
                 margin-left: $pwdub-app-switcher-gutter-mobile;
                 font-size: 14px;
@@ -58,7 +58,7 @@
         width: 50%;
         height: $pwdub-app-switcher-gutter;
         padding-left: $pwdub-app-switcher-gutter;
-        background-color: $pwdub-active;
+        background-color: $pwdub-blue;
         font-size: 14px;
 
         @include tablet {

--- a/src/sass/06_components/_app-switcher.scss
+++ b/src/sass/06_components/_app-switcher.scss
@@ -73,7 +73,7 @@
 .pwd-unity-bar .app-switcher.-on {
 
     > .toggle {
-        background-color: $pwdub-active;
+        background-color: $pwdub-blue;
 
         > .icon,
         > .icon > use > svg {


### PR DESCRIPTION
## Overview

This PR replaces all instances of the bright blue PWD color with the standard (darker) blue PWD color, bringing the unity bar into compliance with standard accessibility guidelines. This impacts the background color of the toggle button (when the menu is open) and the heading of the open menu.

Connects #44 

### Demo

## Before
![image](https://user-images.githubusercontent.com/128699/45376746-9acbce00-b5c6-11e8-9fc1-11676545a078.png)

## After
![image](https://user-images.githubusercontent.com/128699/45376799-bfc04100-b5c6-11e8-8ac3-93981e8b3f68.png)


### Notes

We originally chose the bright blue because it stood out well against various PWD sites that tend to use the default PWD blue. This change means the unity bar may blend in too much against those sites. We should try it for now and see how it goes in the wild, then adjust further if needed.