### PR TITLE
Create enhanced demo app with props toggles & set up Netlify staging site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ tmp
 
 index.html
 dist/report.html
-
+staging/

--- a/Demo.jsx
+++ b/Demo.jsx
@@ -2,83 +2,198 @@ import React, { Component } from 'react';
 import { hot } from 'react-hot-loader/root';
 
 import UnityBar from './src/js/UnityBar';
+import DemoToggles from './DemoToggles';
+
+const accessEnum = Object.freeze({
+    public: 'public',
+    internal: 'internal',
+});
+
+const themeEnum = Object.freeze({
+    blue: 'blue',
+    white: 'white',
+});
 
 class Demo extends Component {
-    constructor(props) {
-        super(props);
+    state = {
+        currentAppName: 'PWD UnityBar',
+        searchValue: '',
+        selectedValue: '',
+        theme: 'blue',
+        access: 'public',
+        hasLogo: true,
+        authenticated: false,
+        hasSearch: true,
+        hasMapAction: false,
+        hasHelpAction: false,
+        hasSettings: false,
+        parcelViewerUrl: 'http://www.phila.gov/water/swmap/',
+        creditsExplorerUrl: 'http://water.phila.gov/swexp/',
+        retrofitMapUrl: 'https://www.azavea.com',
+        retrofitCampaignUrl: 'https://www.azavea.com',
+    };
 
-        this.state = {
-            searchValue: '',
-            selectedValue: '',
-        };
-
-        this.clearSearchBoxValue = this.clearSearchBoxValue.bind(this);
-        this.handleSearchChange = this.handleSearchChange.bind(this);
-        this.handleSearchSubmit = this.handleSearchSubmit.bind(this);
-    }
-
-    clearSearchBoxValue() {
+    clearSearchBoxValue = () =>
         this.setState({
             searchValue: '',
             selectedValue: '',
         });
-    }
 
-    handleSearchChange(searchValue) {
+    handleToggleHasSearch = () =>
+        this.setState(state =>
+            Object.assign({}, state, {
+                hasSearch: !state.hasSearch,
+            }),
+        );
+
+    handleSearchChange = searchValue =>
         this.setState(state =>
             Object.assign({}, state, {
                 searchValue,
             }),
         );
-    }
 
-    handleSearchSubmit(selectedValue) {
+    handleSearchSubmit = selectedValue =>
         this.setState(state =>
             Object.assign({}, state, {
                 selectedValue,
             }),
         );
-    }
+
+    handleChangeAppName = currentAppName =>
+        this.setState(state =>
+            Object.assign({}, state, {
+                currentAppName,
+            }),
+        );
+
+    handleToggleHasLogo = () =>
+        this.setState(state =>
+            Object.assign({}, state, {
+                hasLogo: !state.hasLogo,
+            }),
+        );
+
+    handleToggleAccess = () =>
+        this.setState(state =>
+            Object.assign({}, state, {
+                access:
+                    state.access === accessEnum.public
+                        ? accessEnum.internal
+                        : accessEnum.public,
+            }),
+        );
+
+    handleToggleTheme = () =>
+        this.setState(state =>
+            Object.assign({}, state, {
+                theme:
+                    state.theme === themeEnum.blue
+                        ? themeEnum.white
+                        : themeEnum.blue,
+            }),
+        );
+
+    handleToggleHasMapAction = () =>
+        this.setState(state =>
+            Object.assign({}, state, {
+                hasMapAction: !state.hasMapAction,
+            }),
+        );
+
+    handleToggleHasHelpAction = () =>
+        this.setState(state =>
+            Object.assign({}, state, {
+                hasHelpAction: !state.hasHelpAction,
+            }),
+        );
+
+    handleToggleHasSettings = () =>
+        this.setState(state =>
+            Object.assign({}, state, {
+                hasSettings: !state.hasSettings,
+            }),
+        );
+
+    handleToggleAuthenticated = () =>
+        this.setState(state =>
+            Object.assign({}, state, {
+                authenticated: !state.authenticated,
+            }),
+        );
 
     render() {
-        const { searchValue, selectedValue } = this.state;
+        const {
+            currentAppName,
+            hasLogo,
+            theme,
+            access,
+            hasSearch,
+            searchValue,
+            selectedValue,
+            authenticated,
+            hasMapAction,
+            hasHelpAction,
+            hasSettings,
+            parcelViewerUrl,
+            creditsExplorerUrl,
+            retrofitMapUrl,
+            retrofitCampaignUrl,
+        } = this.state;
 
         return (
             <div>
                 <UnityBar
-                    currentAppName="PWD UnityBar"
-                    authenticated
-                    hasMapAction
+                    currentAppName={currentAppName}
+                    hasLogo={hasLogo}
+                    theme={theme}
+                    authenticated={authenticated}
+                    access={access}
+                    hasMapAction={hasMapAction}
                     mapActionHandler={() => {
                         window.console.log('map action clicked');
                     }}
-                    hasHelpAction
+                    hasHelpAction={hasHelpAction}
                     helpActionHandler={() => {
                         window.console.log('help action clicked');
                     }}
-                    hasSettings
+                    hasSettings={hasSettings}
                     settingsHandler={() => {
                         window.console.log('settings action clicked');
                     }}
                     searchChangeHandler={this.handleSearchChange}
                     searchSubmitHandler={this.handleSearchSubmit}
+                    hasSearch={hasSearch}
                     searchBoxValue={searchValue}
-                    parcelViewerUrl="http://www.phila.gov/water/swmap/"
-                    creditsExplorerUrl="http://water.phila.gov/swexp/"
-                    retrofitMapUrl="https://www.azavea.com"
-                    retrofitCampaignUrl="https://www.azavea.com"
+                    parcelViewerUrl={parcelViewerUrl}
+                    creditsExplorerUrl={creditsExplorerUrl}
+                    retrofitMapUrl={retrofitMapUrl}
+                    retrofitCampaignUrl={retrofitCampaignUrl}
                 />
-                <div id="output-region">
-                    <div>
-                        <p>Search term: {searchValue}</p>
-                    </div>
-                    <div>
-                        <p>Search selection: {selectedValue}</p>
-                    </div>
-                    <button type="button" onClick={this.clearSearchBoxValue}>
-                        Clear search box
-                    </button>
-                </div>
+                <DemoToggles
+                    hasSearch={hasSearch}
+                    searchValue={searchValue}
+                    selectedValue={selectedValue}
+                    clearSearchBoxValue={this.clearSearchBoxValue}
+                    currentAppName={currentAppName}
+                    hasLogo={hasLogo}
+                    theme={theme}
+                    access={access}
+                    authenticated={authenticated}
+                    hasMapAction={hasMapAction}
+                    hasHelpAction={hasHelpAction}
+                    hasSettings={hasSettings}
+                    changeAppName={this.handleChangeAppName}
+                    toggleHasLogo={this.handleToggleHasLogo}
+                    toggleAccess={this.handleToggleAccess}
+                    toggleTheme={this.handleToggleTheme}
+                    toggleHasMapAction={this.handleToggleHasMapAction}
+                    toggleHasHelpAction={this.handleToggleHasHelpAction}
+                    toggleHasSettings={this.handleToggleHasSettings}
+                    toggleAuthenticated={this.handleToggleAuthenticated}
+                    changeSearchValue={this.handleSearchChange}
+                    toggleHasSearch={this.handleToggleHasSearch}
+                />
             </div>
         );
     }

--- a/DemoToggles.jsx
+++ b/DemoToggles.jsx
@@ -1,0 +1,204 @@
+import React from 'react';
+import { bool, func, oneOf, oneOfType, string } from 'prop-types';
+import Grid from '@material-ui/core/Grid';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import TableCell from '@material-ui/core/TableCell';
+import Switch from '@material-ui/core/Switch';
+import Input from '@material-ui/core/Input';
+import Typography from '@material-ui/core/Typography';
+
+const demoTogglesStyles = Object.freeze({
+    containerStyles: Object.freeze({
+        padding: '0.5rem 2rem',
+        display: 'flex',
+        justifyContent: 'center',
+    }),
+    tableStyles: Object.freeze({
+        width: '80%',
+    }),
+    cellStyles: Object.freeze({
+        width: '30%',
+        minWidth: '30%',
+        maxWidth: '30%',
+    }),
+});
+
+const SWITCH_INPUT = 'SWITCH_INPUT';
+const TEXT_INPUT = 'TEXT_INPUT';
+
+function PropsRow({ label, value, inputType, changeHandler, switchCondition }) {
+    return (
+        <TableRow>
+            <TableCell>
+                <code>{label}</code>
+            </TableCell>
+            <TableCell>
+                <code>{value.toString()}</code>
+            </TableCell>
+            <TableCell>
+                {inputType === SWITCH_INPUT ? (
+                    <Switch
+                        checked={
+                            switchCondition ? value === switchCondition : value
+                        }
+                        onChange={changeHandler}
+                    />
+                ) : (
+                    <Input
+                        value={value}
+                        onChange={({ target: { value: v } }) =>
+                            changeHandler(v)
+                        }
+                    />
+                )}
+            </TableCell>
+        </TableRow>
+    );
+}
+
+PropsRow.defaultProps = {
+    switchCondition: null,
+};
+
+PropsRow.propTypes = {
+    label: string.isRequired,
+    value: oneOfType([bool, string]).isRequired,
+    inputType: oneOf([SWITCH_INPUT, TEXT_INPUT]).isRequired,
+    changeHandler: func.isRequired,
+    switchCondition: string,
+};
+
+export default function DemoToggles({
+    hasLogo,
+    toggleHasLogo,
+    theme,
+    toggleTheme,
+    hasSettings,
+    toggleHasSettings,
+    hasMapAction,
+    toggleHasMapAction,
+    hasHelpAction,
+    toggleHasHelpAction,
+    currentAppName,
+    changeAppName,
+    access,
+    toggleAccess,
+    authenticated,
+    toggleAuthenticated,
+    searchValue,
+    changeSearchValue,
+    hasSearch,
+    toggleHasSearch,
+}) {
+    const propsData = [
+        {
+            label: 'currentAppName',
+            value: currentAppName,
+            inputType: TEXT_INPUT,
+            changeHandler: changeAppName,
+        },
+        {
+            label: 'hasLogo',
+            value: hasLogo,
+            inputType: SWITCH_INPUT,
+            changeHandler: toggleHasLogo,
+        },
+        {
+            label: 'hasSettings',
+            value: hasSettings,
+            inputType: SWITCH_INPUT,
+            changeHandler: toggleHasSettings,
+        },
+        {
+            label: 'theme',
+            value: theme,
+            inputType: SWITCH_INPUT,
+            changeHandler: toggleTheme,
+            switchCondition: 'blue',
+        },
+        {
+            label: 'hasMapAction',
+            value: hasMapAction,
+            inputType: SWITCH_INPUT,
+            changeHandler: toggleHasMapAction,
+        },
+        {
+            label: 'hasHelpAction',
+            value: hasHelpAction,
+            inputType: SWITCH_INPUT,
+            changeHandler: toggleHasHelpAction,
+        },
+        {
+            label: 'access',
+            value: access,
+            inputType: SWITCH_INPUT,
+            switchCondition: 'internal',
+            changeHandler: toggleAccess,
+        },
+        {
+            label: 'authenticated',
+            value: authenticated,
+            inputType: SWITCH_INPUT,
+            changeHandler: toggleAuthenticated,
+        },
+        {
+            label: 'hasSearch',
+            value: hasSearch,
+            inputType: SWITCH_INPUT,
+            changeHandler: toggleHasSearch,
+        },
+        {
+            label: 'searchValue',
+            value: searchValue,
+            inputType: TEXT_INPUT,
+            changeHandler: changeSearchValue,
+        },
+    ];
+
+    return (
+        <Grid container style={demoTogglesStyles.containerStyles}>
+            <Table style={demoTogglesStyles.tableStyles}>
+                <TableHead>
+                    <TableRow>
+                        <TableCell style={demoTogglesStyles.cellStyles}>
+                            <Typography variant="h5">prop</Typography>
+                        </TableCell>
+                        <TableCell style={demoTogglesStyles.cellStyles}>
+                            <Typography variant="h5">value</Typography>
+                        </TableCell>
+                        <TableCell style={demoTogglesStyles.cellStyles}>
+                            <Typography variant="h5">change</Typography>
+                        </TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>{propsData.map(PropsRow)}</TableBody>
+            </Table>
+        </Grid>
+    );
+}
+
+DemoToggles.propTypes = {
+    currentAppName: string.isRequired,
+    changeAppName: func.isRequired,
+    hasLogo: bool.isRequired,
+    toggleHasLogo: func.isRequired,
+    theme: oneOf(['blue', 'white']).isRequired,
+    toggleTheme: func.isRequired,
+    hasSettings: bool.isRequired,
+    toggleHasSettings: func.isRequired,
+    hasMapAction: bool.isRequired,
+    toggleHasMapAction: func.isRequired,
+    hasHelpAction: bool.isRequired,
+    toggleHasHelpAction: func.isRequired,
+    access: oneOf(['public', 'internal']).isRequired,
+    toggleAccess: func.isRequired,
+    authenticated: bool.isRequired,
+    toggleAuthenticated: func.isRequired,
+    searchValue: string.isRequired,
+    changeSearchValue: func.isRequired,
+    hasSearch: bool.isRequired,
+    toggleHasSearch: func.isRequired,
+};

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/azavea/pwd-unitybar.svg?branch=develop)](https://travis-ci.org/azavea/pwd-unitybar)
 
+[![Netlify Status](https://api.netlify.com/api/v1/badges/e08902a4-b905-46f4-92be-32149aea344d/deploy-status)](https://app.netlify.com/sites/staging-pwd-unitybar/deploys)
+
 Unified header React component for PWD Stormwater web apps.
 
 ### Requirements

--- a/demo.html
+++ b/demo.html
@@ -3,17 +3,15 @@
   <head>
     <title>PWD UnityBar</title>
     <link rel="stylesheet"
-          href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" />
+        href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" />
+    <link rel="stylesheet"
+        href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <style>
         body {
             margin: 0;
             padding: 0;
             font-family: 'Open Sans', sans-serif;
             box-sizing: border-box;
-        }
-
-        #output-region {
-            margin: 3rem;
         }
     </style>
   </head>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,21 @@
+[Settings]
+  ID = "pwd-unitybar"
+
+[build]
+  base    = "./"
+  publish = "./staging/"
+  command = "npm run cibuild:staging"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+
+[[headers]]
+  for = "/*"
+[headers.values]
+  Content-Security-Policy = "default-src https: blob: data: 'unsafe-inline' 'unsafe-eval'"
+  X-Frame-Options = "DENY"
+  X-XSS-Protection = "1; mode=block"
+  X-Content-Type-Options = "nosniff"
+  Referrer-Policy = "origin-when-cross-origin"

--- a/package-lock.json
+++ b/package-lock.json
@@ -893,6 +893,23 @@
         "@babel/plugin-transform-react-jsx-source": "^7.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
+      "integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
+          "dev": true
+        }
+      }
+    },
     "@babel/runtime-corejs2": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.2.tgz",
@@ -971,6 +988,99 @@
         "esutils": "^2.0.2",
         "lodash": "^4.17.11",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@material-ui/core": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.3.tgz",
+      "integrity": "sha512-REIj62+zEvTgI/C//YL4fZxrCVIySygmpZglsu/Nl5jPqy3CDjZv1F9ubBYorHqmRgeVPh64EghMMWqk4egmfg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "@material-ui/system": "^3.0.0-alpha.0",
+        "@material-ui/utils": "^3.0.0-alpha.2",
+        "@types/jss": "^9.5.6",
+        "@types/react-transition-group": "^2.0.8",
+        "brcast": "^3.0.1",
+        "classnames": "^2.2.5",
+        "csstype": "^2.5.2",
+        "debounce": "^1.1.0",
+        "deepmerge": "^3.0.0",
+        "dom-helpers": "^3.2.1",
+        "hoist-non-react-statics": "^3.2.1",
+        "is-plain-object": "^2.0.4",
+        "jss": "^9.8.7",
+        "jss-camel-case": "^6.0.0",
+        "jss-default-unit": "^8.0.2",
+        "jss-global": "^3.0.0",
+        "jss-nested": "^6.0.1",
+        "jss-props-sort": "^6.0.0",
+        "jss-vendor-prefixer": "^7.0.0",
+        "normalize-scroll-left": "^0.1.2",
+        "popper.js": "^1.14.1",
+        "prop-types": "^15.6.0",
+        "react-event-listener": "^0.6.2",
+        "react-transition-group": "^2.2.1",
+        "recompose": "0.28.0 - 0.30.0",
+        "warning": "^4.0.1"
+      }
+    },
+    "@material-ui/system": {
+      "version": "3.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-3.0.0-alpha.2.tgz",
+      "integrity": "sha512-odmxQ0peKpP7RQBQ8koly06YhsPzcoVib1vByVPBH4QhwqBXuYoqlCjt02846fYspAqkrWzjxnWUD311EBbxOA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "deepmerge": "^3.0.0",
+        "prop-types": "^15.6.0",
+        "warning": "^4.0.1"
+      }
+    },
+    "@material-ui/utils": {
+      "version": "3.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-3.0.0-alpha.3.tgz",
+      "integrity": "sha512-rwMdMZptX0DivkqBuC+Jdq7BYTXwqKai5G5ejPpuEDKpWzi1Oxp+LygGw329FrKpuKeiqpcymlqJTjmy+quWng==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "prop-types": "^15.6.0",
+        "react-is": "^16.6.3"
+      }
+    },
+    "@types/jss": {
+      "version": "9.5.8",
+      "resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.5.8.tgz",
+      "integrity": "sha512-bBbHvjhm42UKki+wZpR89j73ykSXg99/bhuKuYYePtpma3ZAnmeGnl0WxXiZhPGsIfzKwCUkpPC0jlrVMBfRxA==",
+      "dev": true,
+      "requires": {
+        "csstype": "^2.0.0",
+        "indefinite-observable": "^1.0.1"
+      }
+    },
+    "@types/prop-types": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.0.tgz",
+      "integrity": "sha512-eItQyV43bj4rR3JPV0Skpl1SncRCdziTEK9/v8VwXmV6d/qOUO8/EuWeHBbCZcsfSHfzI5UyMJLCSXtxxznyZg==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "16.8.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.10.tgz",
+      "integrity": "sha512-7bUQeZKP4XZH/aB4i7k1i5yuwymDu/hnLMhD9NjVZvQQH7ZUgRN3d6iu8YXzx4sN/tNr0bj8jgguk8hhObzGvA==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.0.16.tgz",
+      "integrity": "sha512-FUJEx2BGJPU1qVQoWd9v7wpOwnCPTWhcE4iTaU5prry9SvwiI11lCXOci8Nz9cM/Fuf650l7Skg6nlVeCYjPFA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@xtuc/ieee754": {
@@ -1627,6 +1737,12 @@
         }
       }
     },
+    "brcast": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
+      "integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg==",
+      "dev": true
+    },
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -1840,6 +1956,12 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
+    },
+    "change-emitter": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU=",
+      "dev": true
     },
     "chardet": {
       "version": "0.7.0",
@@ -2470,6 +2592,12 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+      "dev": true
+    },
     "clean-css": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
@@ -3039,6 +3167,15 @@
         "nth-check": "~1.0.1"
       }
     },
+    "css-vendor": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-0.3.8.tgz",
+      "integrity": "sha1-ZCHP0wNM5mT+dnOXL9ARn8KJQfo=",
+      "dev": true,
+      "requires": {
+        "is-in-browser": "^1.0.2"
+      }
+    },
     "css-what": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
@@ -3049,6 +3186,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true
+    },
+    "csstype": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.3.tgz",
+      "integrity": "sha512-rINUZXOkcBmoHWEyu7JdHu5JMzkGRoMX4ov9830WNgxf5UYxcBUO0QTKAqeJ5EZfSdlrcJYkC8WwfVW7JYi4yg==",
       "dev": true
     },
     "currently-unhandled": {
@@ -3087,6 +3230,12 @@
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
+    "debounce": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
+      "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==",
+      "dev": true
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -3118,6 +3267,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
+      "integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==",
       "dev": true
     },
     "default-gateway": {
@@ -3298,6 +3453,15 @@
           "integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=",
           "dev": true
         }
+      }
+    },
+    "dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.1.2"
       }
     },
     "dom-serializer": {
@@ -5962,6 +6126,12 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "hyphenate-style-name": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
+      "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==",
+      "dev": true
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -6079,6 +6249,15 @@
       "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
       "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
+    },
+    "indefinite-observable": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-1.0.2.tgz",
+      "integrity": "sha512-Mps0898zEduHyPhb7UCgNmfzlqNZknVmaFz5qzr0mm04YQ5FGLhAyK/dJ+NaRxGyR6juQXIxh5Ev0xx+qq0nYA==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.2.0"
+      }
     },
     "indent-string": {
       "version": "2.1.0",
@@ -6350,6 +6529,12 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=",
+      "dev": true
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -6582,6 +6767,84 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jss": {
+      "version": "9.8.7",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-9.8.7.tgz",
+      "integrity": "sha512-awj3XRZYxbrmmrx9LUSj5pXSUfm12m8xzi/VKeqI1ZwWBtQ0kVPTs3vYs32t4rFw83CgFDukA8wKzOE9sMQnoQ==",
+      "dev": true,
+      "requires": {
+        "is-in-browser": "^1.1.3",
+        "symbol-observable": "^1.1.0",
+        "warning": "^3.0.0"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
+      }
+    },
+    "jss-camel-case": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jss-camel-case/-/jss-camel-case-6.1.0.tgz",
+      "integrity": "sha512-HPF2Q7wmNW1t79mCqSeU2vdd/vFFGpkazwvfHMOhPlMgXrJDzdj9viA2SaHk9ZbD5pfL63a8ylp4++irYbbzMQ==",
+      "dev": true,
+      "requires": {
+        "hyphenate-style-name": "^1.0.2"
+      }
+    },
+    "jss-default-unit": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
+      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
+      "dev": true
+    },
+    "jss-global": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
+      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
+      "dev": true
+    },
+    "jss-nested": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jss-nested/-/jss-nested-6.0.1.tgz",
+      "integrity": "sha512-rn964TralHOZxoyEgeq3hXY8hyuCElnvQoVrQwKHVmu55VRDd6IqExAx9be5HgK0yN/+hQdgAXQl/GUrBbbSTA==",
+      "dev": true,
+      "requires": {
+        "warning": "^3.0.0"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
+      }
+    },
+    "jss-props-sort": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
+      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g==",
+      "dev": true
+    },
+    "jss-vendor-prefixer": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz",
+      "integrity": "sha512-Agd+FKmvsI0HLcYXkvy8GYOw3AAASBUpsmIRvVQheps+JWaN892uFOInTr0DRydwaD91vSSUCU4NssschvF7MA==",
+      "dev": true,
+      "requires": {
+        "css-vendor": "^0.3.8"
       }
     },
     "jsx-ast-utils": {
@@ -7482,6 +7745,12 @@
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
+    "normalize-scroll-left": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz",
+      "integrity": "sha512-F9YMRls0zCF6BFIE2YnXDRpHPpfd91nOIaNdDgrx5YMoPLo8Wqj+6jNXHQsYBavJeXP4ww8HCt0xQAKc5qk2Fg==",
+      "dev": true
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -8190,6 +8459,12 @@
         }
       }
     },
+    "popper.js": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.7.tgz",
+      "integrity": "sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ==",
+      "dev": true
+    },
     "portfinder": {
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
@@ -8775,6 +9050,17 @@
         "prop-types": "^15.6.0"
       }
     },
+    "react-event-listener": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.6.tgz",
+      "integrity": "sha512-+hCNqfy7o9wvO6UgjqFmBzARJS7qrNoda0VqzvOuioEpoEXKutiKuv92dSz6kP7rYLmyHPyYNLesi5t/aH1gfw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "prop-types": "^15.6.0",
+        "warning": "^4.0.1"
+      }
+    },
     "react-hot-loader": {
       "version": "4.8.2",
       "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.8.2.tgz",
@@ -8822,6 +9108,31 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.7.0.tgz",
       "integrity": "sha512-IBivBP7xayM7SbbVlAnKgHgoWdfCVqnNBNgQRY5x9iFQm55tFdolR02hX1fCJJtTEKnbaL1stB72/TZc6+p2+Q=="
+    },
+    "react-transition-group": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.8.0.tgz",
+      "integrity": "sha512-So23a1MPn8CGoW5WNU4l0tLiVkOFmeXSS1K4Roe+dxxqqHvI/2XBmj76jx+u96LHnQddWG7LX8QovPAainSmWQ==",
+      "dev": true,
+      "requires": {
+        "dom-helpers": "^3.3.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        }
+      }
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -9168,6 +9479,28 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "recompose": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
+      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "change-emitter": "^0.1.2",
+        "fbjs": "^0.8.1",
+        "hoist-non-react-statics": "^2.3.1",
+        "react-lifecycles-compat": "^3.0.2",
+        "symbol-observable": "^1.0.4"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
           "dev": true
         }
       }
@@ -10302,6 +10635,12 @@
         "has-flag": "^3.0.0"
       }
     },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "dev": true
+    },
     "table": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
@@ -11118,6 +11457,15 @@
       "dev": true,
       "requires": {
         "indexof": "0.0.1"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node_modules/.bin/webpack-dev-server --mode=development --config webpack.dev.config.js --progress --colors --host 0.0.0.0 --port 7777",
     "lint": "node_modules/.bin/eslint src/js/**",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "npm rebuild node-sass --quiet --force"
+    "postinstall": "npm rebuild node-sass --quiet --force",
+    "cibuild:staging": "node_modules/.bin/webpack --mode=production --config webpack.staging.config.js --colors"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@babel/preset-env": "7.4.2",
     "@babel/preset-react": "7.0.0",
     "@babel/runtime-corejs2": "7.4.2",
+    "@material-ui/core": "3.9.3",
     "autoprefixer": "8.2.0",
     "babel-eslint": "10.0.1",
     "babel-loader": "8.0.5",

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -19,6 +19,7 @@ module.exports = {
             analyzerMode: 'server',
             analyzerHost: '0.0.0.0',
             analyzerPort: 7778,
+            openAnalyzer: false,
         }),
         new webpack.DefinePlugin({
             'process.env': {

--- a/webpack.staging.config.js
+++ b/webpack.staging.config.js
@@ -1,0 +1,81 @@
+const path = require('path');
+const webpack = require('webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+
+module.exports = {
+    entry: {
+        app: './App.jsx',
+        vendor: [
+            'react',
+            'react-dom',
+        ]
+    },
+    output: {
+        path: path.join(__dirname, 'staging'),
+        filename: "pwd.unitybar.[hash].js"
+    },
+    plugins: [
+        new webpack.DefinePlugin({
+            'process.env': {
+                'NODE_ENV': JSON.stringify('staging'),
+            },
+        }),
+        new webpack.LoaderOptionsPlugin({
+            test: /\.jsx?$/,
+            options: {
+                eslint: {
+                    configFile: '.eslintrc',
+                },
+            },
+        }),
+        new webpack.SourceMapDevToolPlugin({
+            filename: '[file].map',
+        }),
+        new HtmlWebpackPlugin({
+            filename: 'index.html',
+            template: 'demo.html'
+        }),
+    ],
+    module: {
+        rules: [
+            {
+                test: /\.jsx?$/,
+                exclude: /node_modules/,
+                loader: 'babel-loader',
+                options:
+                {
+                    presets: [
+                        '@babel/preset-env',
+                        '@babel/preset-react',
+                    ],
+                    plugins: [
+                        '@babel/plugin-proposal-class-properties',
+                    ],
+                },
+            },
+            {
+                test: /\.(css|scss)$/,
+                exclude: /node_modules/,
+                use: [
+                    'style-loader',
+                    'css-loader',
+                    'postcss-loader',
+                    'sass-loader',
+                ],
+            },
+            {
+                test: /\.(jpg|gif|png|svg|ttf|eot|woff|woff2)$/,
+                use: 'url-loader',
+            },
+            {
+                test: /\.jsx?/,
+                exclude: [/node_modules/, /\.json$/],
+                loader: 'eslint-loader',
+            },
+        ]
+    },
+    resolve: {
+        extensions: ['.js', '.jsx'],
+    },
+};

--- a/webpack.staging.config.js
+++ b/webpack.staging.config.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 module.exports = {
     entry: {


### PR DESCRIPTION
## Overview

This PR adds a small demo application using material UI which enables users to toggle some of the application's simple props. It also configures the application to deploy via Netlify.

https://deploy-preview-65--staging-pwd-unitybar.netlify.com/

I left out some of the more complex props, including things requiring functions or lists, since it'd be hard to toggle those in a small UI.

Connects #61 
Connects #64 

### Demo

https://deploy-preview-65--staging-pwd-unitybar.netlify.com/

## Testing Instructions

- get this branch then npm install to get the new dependency
- ./scripts/server to run the webpack dev server version, then toggle the props to ensure that they work as expected
- `npm run cibuild:staging` and verify that that also works to create a demo application in the `/staging` dir
