### PR TITLE
Restore jsx-a11y linting rules

### DIFF
--- a/src/js/AppAction.jsx
+++ b/src/js/AppAction.jsx
@@ -1,21 +1,20 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
-
 import React from 'react';
 import { func, string } from 'prop-types';
 
 export default function AppAction({ cssClass, title, onClickHandler, icon }) {
     return (
-        <a
-            className={`link ${cssClass}`}
+        <button
+            className={`link ${cssClass} toggle`}
             title={title}
             href=""
             aria-label={title}
             onClick={onClickHandler}
+            type="button"
         >
             <svg className="icon">
                 <use xlinkHref={icon} />
             </svg>
-        </a>
+        </button>
     );
 }
 

--- a/src/js/AppSummary.jsx
+++ b/src/js/AppSummary.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/aria-props */
-
 import React from 'react';
 import { bool, string } from 'prop-types';
 

--- a/src/js/AuthenticatedActionsMenu.jsx
+++ b/src/js/AuthenticatedActionsMenu.jsx
@@ -1,6 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 import React from 'react';
 import { arrayOf, bool, func, string } from 'prop-types';
 
@@ -24,14 +21,15 @@ export default function AuthenticatedActionsMenu({
         }
 
         const settingsElement = (
-            <a
+            <button
                 className="link"
                 tabIndex={tabIndex}
                 href={settingsHandler ? null : settingsUrl}
                 onClick={settingsHandler || null}
+                type="button"
             >
                 Settings
-            </a>
+            </button>
         );
 
         return (
@@ -48,13 +46,14 @@ export default function AuthenticatedActionsMenu({
                   role="menuitem"
                   key={name + onClickHandler.toString()}
               >
-                  <a
+                  <button
                       className="link"
                       tabIndex={tabIndex}
                       onClick={onClickHandler}
+                      type="button"
                   >
                       {name}
-                  </a>
+                  </button>
               </li>
           ))
         : null;
@@ -87,13 +86,14 @@ export default function AuthenticatedActionsMenu({
                 {customMenuItems}
                 {settingsMenuItem}
                 <li className="listitem" role="menuitem">
-                    <a
+                    <button
                         className="link"
                         tabIndex={tabIndex}
                         onClick={signOutHandler || null}
+                        type="button"
                     >
                         Sign out
-                    </a>
+                    </button>
                 </li>
             </ul>
         </div>

--- a/src/sass/06_components/_additional-actions.scss
+++ b/src/sass/06_components/_additional-actions.scss
@@ -70,7 +70,13 @@
 
         > .listitem > .link {
             @include delinkify($pwdub-white);
+            @include debuttonify;
             cursor: pointer;
+            white-space: nowrap;
+            color: $pwdub-white;
+            font-size: 14px;
+            font-weight: bold;
+            text-transform: uppercase;
         }
     }
 }

--- a/src/sass/06_components/_app-actions.scss
+++ b/src/sass/06_components/_app-actions.scss
@@ -17,12 +17,14 @@
 
     > .link {
         @include delinkify;
+        @include debuttonify;
         display: flex;
         flex: none;
         flex-flow: row nowrap;
         align-items: center;
         justify-content: center;
         width: $pwdub-app-switcher-gutter;
+        cursor: pointer;
 
         &:hover {
             background-color: $pwdub-action-hover-background-color;


### PR DESCRIPTION
## Overview

- replace interactive a elements with buttons
- re-enable jsx-a11y linting rules
- update styles for buttons

Connects #63

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- check out the netlify build to verify that the map, help, and authenticated menu actions are styled appropriately
- run `./scripts/lint` and verify that it passes
- grep for `eslint-disable` and verify that it doesn't appear in the codebase
