### PR TITLE
Configure exports for Stormwater Interactive

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,0 +1,4 @@
+import UnityBar from './UnityBar';
+
+export { UnityBar };
+export default UnityBar;

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -7,7 +7,7 @@ const outputPath = path.join(__dirname, 'dist');
 
 const config = {
     entry: {
-        app: './src/js/UnityBar.jsx',
+        app: './src/js/index.js',
     },
     module: {
         rules: [


### PR DESCRIPTION

## Overview

- set up named exports so that the UnityBar will work with Stormwater
Interactive while continuing to work with GARP

Imitates how the exports are configured here:

https://github.com/ReactTraining/react-router/blob/v3.2.1/modules/index.js

Connects https://github.com/azavea/pwd-stormwater-interactive/issues/524

### Demo

![Screen Shot 2019-04-08 at 4 28 25 PM](https://user-images.githubusercontent.com/4165523/55754733-59e04e80-5a1b-11e9-80c3-40a92e9784cc.png)


### Notes

It's going to be a little hard to review the dist version for this, so I'm going to have to confirm that the release dist works after merging.

I checked this out by

- making a cibuild locally
- manually copying the dist bundle output into my Stormwater Interactive node modules dir

## Testing Instructions

- check that the exports here match the setup from the React Router github link above
