### PR TITLE
Add search field input color to override Bootstrap

### DIFF
--- a/src/sass/06_components/_search-form.scss
+++ b/src/sass/06_components/_search-form.scss
@@ -42,6 +42,7 @@
         background-color: $pwdub-white;
         font: inherit;
         font-size: 15px;
+        color: $pwdub-black;
 
         @include mobile {
             @include invisible;


### PR DESCRIPTION
## Overview

- override the Bootstrap input color settings (and those of other
style-sheets) by giving a specific color property to the search input
field styles

Connects https://github.com/azavea/pwd-stormwater-interactive/issues/524

### Demo

Without the `color` setting:

![Screen Shot 2019-04-09 at 2 47 02 PM](https://user-images.githubusercontent.com/4165523/55826612-68d80700-5ad6-11e9-8ac7-0354d6833724.png)

With the `color` setting:

![Screen Shot 2019-04-09 at 2 46 54 PM](https://user-images.githubusercontent.com/4165523/55826631-72fa0580-5ad6-11e9-94a0-900d929eaff1.png)

## Testing Instructions

The real test will be when this goes into Stormwater Interactive, but for now check the screenshots above and also verify that the Netlify deployment for this branch works correctly.
