### PR TITLE
Submit search input on enter key press

### DIFF
--- a/Demo.jsx
+++ b/Demo.jsx
@@ -54,10 +54,12 @@ class Demo extends Component {
         );
 
     handleSearchSubmit = selectedValue =>
-        this.setState(state =>
-            Object.assign({}, state, {
-                selectedValue,
-            }),
+        this.setState(
+            state =>
+                Object.assign({}, state, {
+                    selectedValue,
+                }),
+            () => window.console.log(`${selectedValue} was submitted`),
         );
 
     handleChangeAppName = currentAppName =>

--- a/DemoToggles.jsx
+++ b/DemoToggles.jsx
@@ -31,7 +31,7 @@ const TEXT_INPUT = 'TEXT_INPUT';
 
 function PropsRow({ label, value, inputType, changeHandler, switchCondition }) {
     return (
-        <TableRow>
+        <TableRow key={label}>
             <TableCell>
                 <code>{label}</code>
             </TableCell>

--- a/src/js/SearchBox.jsx
+++ b/src/js/SearchBox.jsx
@@ -13,10 +13,12 @@ export default function SearchBox({
 }) {
     const tabIndex = searchBoxValue ? '0' : '-1';
 
-    const checkReturnKeyPress = ({ keyCode }) => {
-        if (keyCode === 13) {
-            searchSubmitHandler();
+    const callSubmitActionOnEnterKeyPress = ({ key }) => {
+        if (key === 'Enter') {
+            return searchSubmitHandler();
         }
+
+        return null;
     };
 
     return (
@@ -35,7 +37,7 @@ export default function SearchBox({
                 onFocus={expandSearchBox}
                 onBlur={contractSearchBox}
                 onChange={handleSearchBoxChange}
-                onKeyDown={checkReturnKeyPress}
+                onKeyPress={callSubmitActionOnEnterKeyPress}
             />
             <button
                 onClick={searchSubmitHandler}


### PR DESCRIPTION
## Overview

- updates the search input to call the submit input handler when the
enter key is pressed in the input
- adds a unique key to each table row in the demo app to fix a linter error

Connects https://github.com/azavea/pwd-stormwater-interactive/issues/524

### Demo

![Screen Shot 2019-04-09 at 3 07 05 PM](https://user-images.githubusercontent.com/4165523/55827910-4eebf380-5ad9-11e9-8b64-b520ba465331.png)

## Testing Instructions

- visit the netlify build and open the console
- focus the input and type in a search value, then press enter in the input and verify you see the output logged to the console
