### PR TITLE
Add isSearching & searchingIndicator props

### DIFF
--- a/Demo.jsx
+++ b/Demo.jsx
@@ -18,6 +18,7 @@ class Demo extends Component {
     state = {
         currentAppName: 'PWD UnityBar',
         searchValue: '',
+        isSearching: false,
         selectedValue: '',
         theme: 'blue',
         access: 'public',
@@ -60,6 +61,13 @@ class Demo extends Component {
                     selectedValue,
                 }),
             () => window.console.log(`${selectedValue} was submitted`),
+        );
+
+    handleToggleIsSearching = () =>
+        this.setState(state =>
+            Object.assign({}, state, {
+                isSearching: !state.isSearching,
+            }),
         );
 
     handleChangeAppName = currentAppName =>
@@ -141,7 +149,18 @@ class Demo extends Component {
             creditsExplorerUrl,
             retrofitMapUrl,
             retrofitCampaignUrl,
+            isSearching,
         } = this.state;
+
+        const searchingElement = (
+            <span
+                role="img"
+                className="icon"
+                aria-label="hourglass image for loading indicator"
+            >
+                ⌛
+            </span>
+        );
 
         return (
             <div>
@@ -171,6 +190,8 @@ class Demo extends Component {
                     creditsExplorerUrl={creditsExplorerUrl}
                     retrofitMapUrl={retrofitMapUrl}
                     retrofitCampaignUrl={retrofitCampaignUrl}
+                    isSearching={isSearching}
+                    searchingIndicator={searchingElement}
                 />
                 <DemoToggles
                     hasSearch={hasSearch}
@@ -195,6 +216,8 @@ class Demo extends Component {
                     toggleAuthenticated={this.handleToggleAuthenticated}
                     changeSearchValue={this.handleSearchChange}
                     toggleHasSearch={this.handleToggleHasSearch}
+                    isSearching={isSearching}
+                    toggleIsSearching={this.handleToggleIsSearching}
                 />
             </div>
         );

--- a/DemoToggles.jsx
+++ b/DemoToggles.jsx
@@ -92,6 +92,8 @@ export default function DemoToggles({
     changeSearchValue,
     hasSearch,
     toggleHasSearch,
+    isSearching,
+    toggleIsSearching,
 }) {
     const propsData = [
         {
@@ -156,6 +158,12 @@ export default function DemoToggles({
             inputType: TEXT_INPUT,
             changeHandler: changeSearchValue,
         },
+        {
+            label: 'isSearching',
+            value: isSearching,
+            inputType: SWITCH_INPUT,
+            changeHandler: toggleIsSearching,
+        },
     ];
 
     return (
@@ -201,4 +209,6 @@ DemoToggles.propTypes = {
     changeSearchValue: func.isRequired,
     hasSearch: bool.isRequired,
     toggleHasSearch: func.isRequired,
+    isSearching: bool.isRequired,
+    toggleIsSearching: func.isRequired,
 };

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ following props:
 | searchChangeHandler | function | Function to handle changes to the search bar input | `console.log` |
 | searchSubmitHandler | function | Function to handle search bar input submission | `console.log` |
 | searchBoxValue | string | Current [controlled input](https://reactjs.org/docs/forms.html#controlled-components) value | `""` |
+| isSearching | bool | Disable the search input field and button while fetching | `false` |
+| searchingIndicator | node | React component to use as a loading indicator while isSearching is true | `null` |
 | hasMapAction | bool | Display the map action button | `true` |
 | hasHelpAction | bool | Display the help action button | `true` |
 | helpActionHandler | function | Function to handle clicks on the help action button | `null` |

--- a/src/js/AppActions.jsx
+++ b/src/js/AppActions.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { arrayOf, bool, func, string } from 'prop-types';
+import { arrayOf, bool, func, node, string } from 'prop-types';
 
 import { customActionPropType, customMenuOptionPropType } from './constants';
 
@@ -28,6 +28,8 @@ export default function AppActions({
     hasSearch,
     searchPlaceholder,
     searchSubmitHandler,
+    isSearching,
+    searchingIndicator,
     hasMapAction,
     mapActionHandler,
     hasHelpAction,
@@ -108,6 +110,8 @@ export default function AppActions({
             contractSearchBox={contractSearchBox}
             searchBoxValue={searchBoxValue}
             handleSearchBoxChange={handleSearchBoxChange}
+            isSearching={isSearching}
+            searchingIndicator={searchingIndicator}
         />
     ) : null;
 
@@ -147,6 +151,8 @@ AppActions.defaultProps = {
     closeAuthenticatedActions: () => null,
     hasSearch: false,
     searchPlaceholder: '',
+    isSearching: false,
+    searchingIndicator: null,
     hasMapAction: false,
     mapActionHandler: () => null,
     hasHelpAction: false,
@@ -171,6 +177,8 @@ AppActions.propTypes = {
     hasSearch: bool,
     searchPlaceholder: string,
     searchSubmitHandler: func.isRequired,
+    isSearching: bool,
+    searchingIndicator: node,
     hasMapAction: bool,
     mapActionHandler: func,
     hasHelpAction: bool,

--- a/src/js/SearchBox.jsx
+++ b/src/js/SearchBox.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { string, func } from 'prop-types';
+import { bool, node, string, func } from 'prop-types';
 
 const searchBoxRole = 'searchbox';
 
@@ -10,6 +10,8 @@ export default function SearchBox({
     contractSearchBox,
     searchBoxValue,
     handleSearchBoxChange,
+    isSearching,
+    searchingIndicator,
 }) {
     const tabIndex = searchBoxValue ? '0' : '-1';
 
@@ -21,11 +23,27 @@ export default function SearchBox({
         return null;
     };
 
-    return (
-        <div className="search-form" role="search">
+    const searchIcon = (() => {
+        const searchSVG = (
             <svg className="icon" aria-hidden="true">
                 <use xlinkHref="#pwdub-icon-search" />
             </svg>
+        );
+
+        if (!isSearching) {
+            return searchSVG;
+        }
+
+        if (!searchingIndicator) {
+            return searchSVG;
+        }
+
+        return searchingIndicator;
+    })();
+
+    return (
+        <div className="search-form" role="search">
+            {searchIcon}
             <input
                 className="field"
                 type="search"
@@ -38,6 +56,7 @@ export default function SearchBox({
                 onBlur={contractSearchBox}
                 onChange={handleSearchBoxChange}
                 onKeyPress={callSubmitActionOnEnterKeyPress}
+                disabled={isSearching}
             />
             <button
                 onClick={searchSubmitHandler}
@@ -45,12 +64,17 @@ export default function SearchBox({
                 type="button"
                 name="search-btn"
                 tabIndex={tabIndex}
+                disabled={isSearching}
             >
                 Search
             </button>
         </div>
     );
 }
+
+SearchBox.defaultProps = {
+    searchingIndicator: null,
+};
 
 SearchBox.propTypes = {
     searchPlaceholder: string.isRequired,
@@ -59,4 +83,6 @@ SearchBox.propTypes = {
     contractSearchBox: func.isRequired,
     searchBoxValue: string.isRequired,
     handleSearchBoxChange: func.isRequired,
+    isSearching: bool.isRequired,
+    searchingIndicator: node,
 };

--- a/src/js/UnityBar.jsx
+++ b/src/js/UnityBar.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { arrayOf, bool, func, string } from 'prop-types';
+import { arrayOf, bool, func, node, string } from 'prop-types';
 import onClickOutside from 'react-onclickoutside';
 
 import {
@@ -116,6 +116,8 @@ class UnityBar extends Component {
             searchPlaceholder,
             searchSubmitHandler,
             searchBoxValue,
+            isSearching,
+            searchingIndicator,
             hasMapAction,
             mapActionHandler,
             hasHelpAction,
@@ -230,6 +232,8 @@ class UnityBar extends Component {
                     hasSearch={hasSearch}
                     searchPlaceholder={searchPlaceholder}
                     searchSubmitHandler={wrappedSearchSubmitHandler}
+                    isSearching={isSearching}
+                    searchingIndicator={searchingIndicator}
                     hasMapAction={hasMapAction}
                     mapActionHandler={wrappedMapActionHandler}
                     hasHelpAction={hasHelpAction}
@@ -263,6 +267,8 @@ UnityBar.propTypes = {
     searchChangeHandler: func,
     searchSubmitHandler: func,
     searchBoxValue: string,
+    isSearching: bool,
+    searchingIndicator: node,
     hasMapAction: bool,
     mapActionHandler: func,
     hasHelpAction: bool,
@@ -297,6 +303,8 @@ UnityBar.defaultProps = {
         }
     },
     searchBoxValue: '',
+    isSearching: false,
+    searchingIndicator: null,
     hasMapAction: true,
     hasHelpAction: true,
     authenticated: false,


### PR DESCRIPTION
## Overview

Add `isSearching` bool prop to disable the search inputs during fetching
states. Passed in from above to enable treating the input as controlled.

Add `searchingIndicator` node prop to use as the loading indicator, passed
in as whatever React component the application wants to use.

Connects https://github.com/azavea/pwd-stormwater-interactive/issues/524

### Demo

Not fetching ->

![Screen Shot 2019-04-09 at 5 11 21 PM](https://user-images.githubusercontent.com/4165523/55835703-8a42ee00-5aea-11e9-9ffb-5d8ae8e20733.png)

Fetching ->

![Screen Shot 2019-04-09 at 5 11 28 PM](https://user-images.githubusercontent.com/4165523/55835709-8f07a200-5aea-11e9-98e4-9e19ca83bbf3.png)

## Testing Instructions

- check out the Netlify build and verify that the search icon updates as expected when you toggle the `isSearching` prop. the `searchingIndicator` is currently hard coded in the demo app, but it will be passed in from above by whatever other application.
