### PR TITLE
Add appNameClickHandler prop

### DIFF
--- a/Demo.jsx
+++ b/Demo.jsx
@@ -32,6 +32,7 @@ class Demo extends Component {
         creditsExplorerUrl: 'http://water.phila.gov/swexp/',
         retrofitMapUrl: 'https://www.azavea.com',
         retrofitCampaignUrl: 'https://www.azavea.com',
+        hasAppNameClickHandler: false,
     };
 
     clearSearchBoxValue = () =>
@@ -132,9 +133,19 @@ class Demo extends Component {
             }),
         );
 
+    handleAppNameClick = () => window.console.log('App name was clicked!');
+
+    handleToggleHasAppNameClickHandler = () =>
+        this.setState(state =>
+            Object.assign({}, state, {
+                hasAppNameClickHandler: !state.hasAppNameClickHandler,
+            }),
+        );
+
     render() {
         const {
             currentAppName,
+            hasAppNameClickHandler,
             hasLogo,
             theme,
             access,
@@ -166,6 +177,9 @@ class Demo extends Component {
             <div>
                 <UnityBar
                     currentAppName={currentAppName}
+                    appNameClickHandler={
+                        hasAppNameClickHandler ? this.handleAppNameClick : null
+                    }
                     hasLogo={hasLogo}
                     theme={theme}
                     authenticated={authenticated}
@@ -199,6 +213,10 @@ class Demo extends Component {
                     selectedValue={selectedValue}
                     clearSearchBoxValue={this.clearSearchBoxValue}
                     currentAppName={currentAppName}
+                    hasAppNameClickHandler={hasAppNameClickHandler}
+                    toggleHasAppNameClickHandler={
+                        this.handleToggleHasAppNameClickHandler
+                    }
                     hasLogo={hasLogo}
                     theme={theme}
                     access={access}

--- a/DemoToggles.jsx
+++ b/DemoToggles.jsx
@@ -28,6 +28,7 @@ const demoTogglesStyles = Object.freeze({
 
 const SWITCH_INPUT = 'SWITCH_INPUT';
 const TEXT_INPUT = 'TEXT_INPUT';
+const APP_NAME_CLICK_HANDLER = 'appNameClickHandler';
 
 function PropsRow({ label, value, inputType, changeHandler, switchCondition }) {
     return (
@@ -36,7 +37,11 @@ function PropsRow({ label, value, inputType, changeHandler, switchCondition }) {
                 <code>{label}</code>
             </TableCell>
             <TableCell>
-                <code>{value.toString()}</code>
+                <code>
+                    {label !== APP_NAME_CLICK_HANDLER
+                        ? value.toString()
+                        : (value && 'Function') || 'null'}
+                </code>
             </TableCell>
             <TableCell>
                 {inputType === SWITCH_INPUT ? (
@@ -84,6 +89,8 @@ export default function DemoToggles({
     toggleHasHelpAction,
     currentAppName,
     changeAppName,
+    hasAppNameClickHandler,
+    toggleHasAppNameClickHandler,
     access,
     toggleAccess,
     authenticated,
@@ -101,6 +108,12 @@ export default function DemoToggles({
             value: currentAppName,
             inputType: TEXT_INPUT,
             changeHandler: changeAppName,
+        },
+        {
+            label: APP_NAME_CLICK_HANDLER,
+            value: hasAppNameClickHandler,
+            inputType: SWITCH_INPUT,
+            changeHandler: toggleHasAppNameClickHandler,
         },
         {
             label: 'hasLogo',
@@ -191,6 +204,8 @@ export default function DemoToggles({
 DemoToggles.propTypes = {
     currentAppName: string.isRequired,
     changeAppName: func.isRequired,
+    hasAppNameClickHandler: bool.isRequired,
+    toggleHasAppNameClickHandler: func.isRequired,
     hasLogo: bool.isRequired,
     toggleHasLogo: func.isRequired,
     theme: oneOf(['blue', 'white']).isRequired,

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ following props:
 | name | type | description | default |
 | --- | --- | --- | --- |
 | currentAppName | string | The name of the current app | `null` (required) |
+| appNameClickHandler | function | An optional function to call on clicking the app name. Makes the app name into a button | `null` |
 | theme | string | UnityBar theme (`"blue"`, `"white"`, or `"custom"`) | `"blue"` |
 | access | string | Access level (`"public"` or `"internal"`) | `"public"` |
 | hasLogo | bool | Display the PWD logo | `true` |

--- a/src/js/AppSwitcher.jsx
+++ b/src/js/AppSwitcher.jsx
@@ -5,6 +5,7 @@ import AppSummary from './AppSummary';
 
 export default function AppSwitcher({
     currentAppName,
+    appNameClickHandler,
     appSwitcherOpen,
     openAppSwitcher,
     closeAppSwitcher,
@@ -55,9 +56,23 @@ export default function AppSwitcher({
     const appSwitcherOpenCSSClass = appSwitcherOpen ? '-on' : '';
     const tabIndex = appSwitcherOpen ? '0' : '-1';
 
+    const appNameHeader = appNameClickHandler ? (
+        <button
+            className="appname"
+            type="button"
+            title={currentAppName}
+            aria-label={currentAppName}
+            onClick={appNameClickHandler}
+            style={{ cursor: 'pointer' }}
+        >
+            {currentAppName}
+        </button>
+    ) : (
+        <h1 className="appname">{currentAppName}</h1>
+    );
+
     return (
         <div className={`app-switcher ${appSwitcherOpenCSSClass}`}>
-            <h1 className="appname">{currentAppName}</h1>
             <button
                 className="toggle"
                 type="button"
@@ -73,6 +88,7 @@ export default function AppSwitcher({
                     <use xlinkHref="#pwdub-icon-back" />
                 </svg>
             </button>
+            {appNameHeader}
             <div className="app-switcher-menu" aria-hidden="true">
                 <header className="menu-header">
                     <h2 className="heading">Stormwater Management Apps</h2>
@@ -96,10 +112,12 @@ export default function AppSwitcher({
 
 AppSwitcher.defaultProps = {
     appConfig: [],
+    appNameClickHandler: null,
 };
 
 AppSwitcher.propTypes = {
     currentAppName: string.isRequired,
+    appNameClickHandler: func,
     appSwitcherOpen: bool.isRequired,
     openAppSwitcher: func.isRequired,
     closeAppSwitcher: func.isRequired,

--- a/src/js/UnityBar.jsx
+++ b/src/js/UnityBar.jsx
@@ -43,6 +43,7 @@ class UnityBar extends Component {
         this.closeAllElements = this.closeAllElements.bind(this);
         this.handleSearchBoxChange = this.handleSearchBoxChange.bind(this);
         this.clearSearchBoxValue = this.clearSearchBoxValue.bind(this);
+        this.handleAppNameClick = this.handleAppNameClick.bind(this);
     }
 
     clearSearchBoxValue() {
@@ -106,9 +107,24 @@ class UnityBar extends Component {
         }
     }
 
+    handleAppNameClick() {
+        const { appNameClickHandler } = this.props;
+
+        return this.setState(
+            state =>
+                Object.assign({}, state, {
+                    appSwitcherOpen: false,
+                    authenticatedActionsOpen: false,
+                    searchBoxExpanded: false,
+                }),
+            appNameClickHandler,
+        );
+    }
+
     render() {
         const {
             currentAppName,
+            appNameClickHandler,
             theme,
             access,
             hasLogo,
@@ -221,6 +237,9 @@ class UnityBar extends Component {
                     openAppSwitcher={this.openAppSwitcher}
                     closeAppSwitcher={this.closeAppSwitcher}
                     currentAppName={currentAppName}
+                    appNameClickHandler={
+                        appNameClickHandler ? this.handleAppNameClick : null
+                    }
                     appConfig={appConfig}
                 />
                 {pwdLogo}
@@ -259,6 +278,7 @@ class UnityBar extends Component {
 
 UnityBar.propTypes = {
     currentAppName: string.isRequired,
+    appNameClickHandler: func,
     theme: string,
     access: accessPropType,
     hasLogo: bool,
@@ -287,6 +307,7 @@ UnityBar.propTypes = {
 };
 
 UnityBar.defaultProps = {
+    appNameClickHandler: null,
     theme: 'blue',
     access: 'public',
     hasLogo: true,

--- a/src/sass/02_tools/_mixins.scss
+++ b/src/sass/02_tools/_mixins.scss
@@ -15,6 +15,8 @@
     background: none;
     line-height: 1;
     appearance: none;
+    font-family: inherit;
+    color: inherit;
 }
 
 @mixin replace-with-image($image, $size : contain) {

--- a/src/sass/06_components/_app-switcher.scss
+++ b/src/sass/06_components/_app-switcher.scss
@@ -6,7 +6,7 @@
     justify-content: flex-start;
 
     > .appname {
-        order: 1;
+        @include debuttonify;
         font-size: 16px;
         font-weight: bold;
         line-height: 1.2;


### PR DESCRIPTION
## Overview

Add appNameClickHandler prop which host applications can use to pass a
function in to be called when clicking the app name. This is done in
order to enable using the app name for routing via react-router
functions.

Connects https://github.com/azavea/pwd-stormwater-interactive/issues/524

## Notes

~Having slight trouble getting the text to keep identical formatting which you can see when toggling. In practice toggling would likely not happen within the same app session but for sake of regularity it'd be nice to have both h1 and button versions be the same.~ Fixed this and a tabindex issue with Scott's help!

## Testing Instructions

- check the Netlify deploy preview and then toggle the `appNameClickHandler` setting on and off
- when `off` the app name should be a normal `h1` tag and not clickable
- when `on` the app name should be a `button` tag and clickable
