### PR TITLE
Enable hiding apps in app switcher

### DIFF
--- a/Demo.jsx
+++ b/Demo.jsx
@@ -31,11 +31,43 @@ class Demo extends Component {
         helpActionTitle: 'Help',
         hasSettings: false,
         parcelViewerUrl: 'http://www.phila.gov/water/swmap/',
+        showParcelViewerLink: true,
         creditsExplorerUrl: 'http://water.phila.gov/swexp/',
+        showCreditsExplorerLink: true,
         retrofitMapUrl: 'https://www.azavea.com',
+        showRetrofitMapLink: true,
         retrofitCampaignUrl: 'https://www.azavea.com',
+        showRetrofitCampaignLink: true,
         hasAppNameClickHandler: false,
     };
+
+    handleToggleShowParcelViewerLink = () =>
+        this.setState(state =>
+            Object.assign({}, state, {
+                showParcelViewerLink: !state.showParcelViewerLink,
+            }),
+        );
+
+    handleToggleShowCreditsExplorerLink = () =>
+        this.setState(state =>
+            Object.assign({}, state, {
+                showCreditsExplorerLink: !state.showCreditsExplorerLink,
+            }),
+        );
+
+    handleToggleShowRetrofitMapLink = () =>
+        this.setState(state =>
+            Object.assign({}, state, {
+                showRetrofitMapLink: !state.showRetrofitMapLink,
+            }),
+        );
+
+    handleToggleShowRetrofitCampaignLink = () =>
+        this.setState(state =>
+            Object.assign({}, state, {
+                showRetrofitCampaignLink: !state.showRetrofitCampaignLink,
+            }),
+        );
 
     clearSearchBoxValue = () =>
         this.setState({
@@ -175,9 +207,13 @@ class Demo extends Component {
             helpActionTitle,
             hasSettings,
             parcelViewerUrl,
+            showParcelViewerLink,
             creditsExplorerUrl,
+            showCreditsExplorerLink,
             retrofitMapUrl,
+            showRetrofitMapLink,
             retrofitCampaignUrl,
+            showRetrofitCampaignLink,
             isSearching,
         } = this.state;
 
@@ -221,9 +257,13 @@ class Demo extends Component {
                     hasSearch={hasSearch}
                     searchBoxValue={searchValue}
                     parcelViewerUrl={parcelViewerUrl}
+                    showParcelViewerLink={showParcelViewerLink}
                     creditsExplorerUrl={creditsExplorerUrl}
+                    showCreditsExplorerLink={showCreditsExplorerLink}
                     retrofitMapUrl={retrofitMapUrl}
+                    showRetrofitMapLink={showRetrofitMapLink}
                     retrofitCampaignUrl={retrofitCampaignUrl}
+                    showRetrofitCampaignLink={showRetrofitCampaignLink}
                     isSearching={isSearching}
                     searchingIndicator={searchingElement}
                 />
@@ -260,6 +300,22 @@ class Demo extends Component {
                     toggleHasSearch={this.handleToggleHasSearch}
                     isSearching={isSearching}
                     toggleIsSearching={this.handleToggleIsSearching}
+                    showParcelViewerLink={showParcelViewerLink}
+                    toggleShowParcelViewerLink={
+                        this.handleToggleShowParcelViewerLink
+                    }
+                    showCreditsExplorerLink={showCreditsExplorerLink}
+                    toggleShowCreditsExplorerLink={
+                        this.handleToggleShowCreditsExplorerLink
+                    }
+                    showRetrofitCampaignLink={showRetrofitCampaignLink}
+                    toggleShowRetrofitCampaignLink={
+                        this.handleToggleShowRetrofitCampaignLink
+                    }
+                    showRetrofitMapLink={showRetrofitMapLink}
+                    toggleShowRetrofitMapLink={
+                        this.handleToggleShowRetrofitMapLink
+                    }
                 />
             </div>
         );

--- a/DemoToggles.jsx
+++ b/DemoToggles.jsx
@@ -105,6 +105,14 @@ export default function DemoToggles({
     toggleHasSearch,
     isSearching,
     toggleIsSearching,
+    showParcelViewerLink,
+    toggleShowParcelViewerLink,
+    showCreditsExplorerLink,
+    toggleShowCreditsExplorerLink,
+    showRetrofitMapLink,
+    toggleShowRetrofitMapLink,
+    showRetrofitCampaignLink,
+    toggleShowRetrofitCampaignLink,
 }) {
     const propsData = [
         {
@@ -193,6 +201,30 @@ export default function DemoToggles({
             inputType: SWITCH_INPUT,
             changeHandler: toggleIsSearching,
         },
+        {
+            label: 'showParcelViewerLink',
+            value: showParcelViewerLink,
+            inputType: SWITCH_INPUT,
+            changeHandler: toggleShowParcelViewerLink,
+        },
+        {
+            label: 'showCreditsExplorerLink',
+            value: showCreditsExplorerLink,
+            inputType: SWITCH_INPUT,
+            changeHandler: toggleShowCreditsExplorerLink,
+        },
+        {
+            label: 'showRetrofitMapLink',
+            value: showRetrofitMapLink,
+            inputType: SWITCH_INPUT,
+            changeHandler: toggleShowRetrofitMapLink,
+        },
+        {
+            label: 'showRetrofitCampaignLink',
+            value: showRetrofitCampaignLink,
+            inputType: SWITCH_INPUT,
+            changeHandler: toggleShowRetrofitCampaignLink,
+        },
     ];
 
     return (
@@ -246,4 +278,12 @@ DemoToggles.propTypes = {
     toggleHasSearch: func.isRequired,
     isSearching: bool.isRequired,
     toggleIsSearching: func.isRequired,
+    showParcelViewerLink: bool.isRequired,
+    toggleShowParcelViewerLink: func.isRequired,
+    showCreditsExplorerLink: bool.isRequired,
+    toggleShowCreditsExplorerLink: func.isRequired,
+    showRetrofitMapLink: bool.isRequired,
+    toggleShowRetrofitMapLink: func.isRequired,
+    showRetrofitCampaignLink: bool.isRequired,
+    toggleShowRetrofitCampaignLink: func.isRequired,
 };

--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ following props:
 | signOutHandler | function | Function to handle clicking sign out | `console.log` |
 | customMenuOptions | array | An array of [custom menu options](https://github.com/azavea/pwd-unitybar/blob/develop/src/js/constants.js#L26) | `null` |
 | parcelViewerUrl | string | Link to the Stormwater Parcel Viewer website | `""` |
+| showParcelViewerLink | bool | Display a link to the Parcel Viewer | `true` |
 | creditsExplorerUrl | string | Link to the Stormwater Credits Explorer website | `""` |
+| showCreditsExplorerLink | bool | Display a link to the Credits Explorer | `true` |
 | retrofitMapUrl | string | Link to the Stormwater Connect Map website. | `""` |
+| showRetrofitMapLink | bool | Display a link to the Stormwater Connect Map site | `true` |
 | retrofitCampaignUrl | string | Link to the Stormwater Connect website. | `""` |
+| showRetrofitCampaignLink | bool | Display a link to the Stormwater Connect marketing site | `true` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1288,9 +1288,9 @@
       }
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
       "dev": true
     },
     "acorn-dynamic-import": {
@@ -1303,6 +1303,12 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
       "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+      "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
       "dev": true
     },
     "ajv": {
@@ -1807,9 +1813,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
       "dev": true
     },
     "bn.js": {
@@ -5389,13 +5395,21 @@
       "dev": true
     },
     "gzip-size": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
-      "integrity": "sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.0.tgz",
+      "integrity": "sha512-wfSnvypBDRW94v5W3ckvvz/zFUNdJ81VgOP6tE4bPpRUcc0wGqU+y0eZjJEvKxwubJFix6P84sE8M51YWLT7rQ==",
       "dev": true,
       "requires": {
         "duplexer": "^0.1.1",
-        "pify": "^3.0.0"
+        "pify": "^4.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
       }
     },
     "handle-thing": {
@@ -11112,12 +11126,13 @@
       }
     },
     "webpack-bundle-analyzer": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.0.3.tgz",
-      "integrity": "sha512-naLWiRfmtH4UJgtUktRTLw6FdoZJ2RvCR9ePbwM9aRMsS/KjFerkPZG9epEvXRAw5d5oPdrs9+3p+afNjxW8Xw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.3.2.tgz",
+      "integrity": "sha512-7qvJLPKB4rRWZGjVp5U1KEjwutbDHSKboAl0IfafnrdXMrgC0tOtZbQD6Rw0u4cmpgRN4O02Fc0t8eAT+FgGzA==",
       "dev": true,
       "requires": {
-        "acorn": "^5.7.3",
+        "acorn": "^6.0.7",
+        "acorn-walk": "^6.1.1",
         "bfj": "^6.1.1",
         "chalk": "^2.4.1",
         "commander": "^2.18.0",
@@ -11787,9 +11802,9 @@
       }
     },
     "ws": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
-      "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
       "dev": true,
       "requires": {
         "async-limiter": "~1.0.0"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "style-loader": "0.18.2",
     "url-loader": "1.1.1",
     "webpack": "4.30.0",
-    "webpack-bundle-analyzer": "3.0.3",
+    "webpack-bundle-analyzer": "3.3.2",
     "webpack-cli": "3.2.0",
     "webpack-dev-server": "3.2.1"
   }

--- a/src/js/AppSwitcher.jsx
+++ b/src/js/AppSwitcher.jsx
@@ -18,12 +18,21 @@ export default function AppSwitcher({
             appName,
             appDescription,
             appUrl,
+            isVisible,
             secondAppName,
             secondAppDescription,
             secondAppUrl,
+            secondAppIsVisible,
         }) => {
+            if (!isVisible) {
+                return null;
+            }
+
             const secondaryApp =
-                secondAppName && secondAppDescription && secondAppUrl ? (
+                secondAppName &&
+                secondAppDescription &&
+                secondAppUrl &&
+                secondAppIsVisible ? (
                     <AppSummary
                         appSwitcherOpen={appSwitcherOpen}
                         name={secondAppName}
@@ -127,9 +136,11 @@ AppSwitcher.propTypes = {
             appHeading: string,
             appName: string,
             appUrl: string,
+            isVisible: bool,
             secondAppName: string,
             secondAppDescription: string,
             secondAppUrl: string,
+            secondAppIsVisible: bool,
         }),
     ),
 };

--- a/src/js/UnityBar.jsx
+++ b/src/js/UnityBar.jsx
@@ -151,6 +151,10 @@ class UnityBar extends Component {
             creditsExplorerUrl,
             retrofitMapUrl,
             retrofitCampaignUrl,
+            showParcelViewerLink,
+            showCreditsExplorerLink,
+            showRetrofitMapLink,
+            showRetrofitCampaignLink,
         } = this.props;
 
         const {
@@ -164,15 +168,19 @@ class UnityBar extends Component {
                 case PARCEL_VIEWER:
                     return Object.assign({}, config, {
                         appUrl: parcelViewerUrl,
+                        isVisible: showParcelViewerLink,
                     });
                 case RETROFIT_MAP:
                     return Object.assign({}, config, {
                         appUrl: retrofitMapUrl,
+                        isVisible: showRetrofitMapLink,
                     });
                 case CREDITS_EXPLORER:
                     return Object.assign({}, config, {
                         appUrl: creditsExplorerUrl,
                         secondAppUrl: retrofitCampaignUrl,
+                        isVisible: showCreditsExplorerLink,
+                        secondAppIsVisible: showRetrofitCampaignLink,
                     });
                 default:
                     return config;
@@ -310,6 +318,10 @@ UnityBar.propTypes = {
     creditsExplorerUrl: string,
     retrofitMapUrl: string,
     retrofitCampaignUrl: string,
+    showParcelViewerLink: bool,
+    showCreditsExplorerLink: bool,
+    showRetrofitMapLink: bool,
+    showRetrofitCampaignLink: bool,
 };
 
 UnityBar.defaultProps = {
@@ -347,6 +359,10 @@ UnityBar.defaultProps = {
     creditsExplorerUrl: '',
     retrofitMapUrl: '',
     retrofitCampaignUrl: '',
+    showParcelViewerLink: true,
+    showCreditsExplorerLink: true,
+    showRetrofitMapLink: true,
+    showRetrofitCampaignLink: true,
     mapActionHandler: () => null,
     helpActionHandler: () => null,
     customActions: [],


### PR DESCRIPTION
## Overview

This PR enables hiding specific apps from the app switcher menu so that we can use the Unity Bar in applications which have been deployed while other applications have not been deployed.

First commit here fixes an issue via npm audit fix.

Connects #83 

### Demo

![Screen Shot 2019-04-26 at 11 40 56 AM](https://user-images.githubusercontent.com/4165523/56819655-2c1b4800-6818-11e9-9a5e-1ced04a5e76b.png)

### Notes

I intentionally did not attempt to change the width or of the App Switcher when not all of the apps are visible. If it becomes desirable to do that in the future -- for instance, if there's a long interval between the PV deployment and GARP deployment -- then we can handle it in another issue.

## Testing Instructions

- visit the netlify site
- toggle the apps in the app switcher and verify that they are displayed or hidden properly
