### PR TITLE
Make staging site work in IE 11

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1,3 +1,4 @@
+import 'core-js';
 import React from 'react';
 import { render } from 'react-dom';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3114,9 +3114,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
       "dev": true
     },
     "core-js-compat": {
@@ -4604,6 +4604,14 @@
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
         "ua-parser-js": "^0.7.18"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        }
       }
     },
     "figgy-pudding": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5179,9 +5179,9 @@
       "dev": true
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -10429,13 +10429,13 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "autoprefixer": "8.2.0",
     "babel-eslint": "10.0.1",
     "babel-loader": "8.0.5",
+    "core-js": "2.6.5",
     "css-loader": "2.1.1",
     "debug": "2.6.9",
     "eslint": "5.16.0",

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -68,8 +68,14 @@ module.exports = {
                 options:
                 {
                     presets: [
-                        '@babel/preset-env',
                         '@babel/preset-react',
+                        [
+                            '@babel/preset-env',
+                            {
+                                useBuiltIns: 'entry',
+                                corejs: '2',
+                            },
+                        ],
                     ],
                     plugins: [
                         '@babel/plugin-proposal-class-properties',

--- a/webpack.staging.config.js
+++ b/webpack.staging.config.js
@@ -45,8 +45,14 @@ module.exports = {
                 options:
                 {
                     presets: [
-                        '@babel/preset-env',
                         '@babel/preset-react',
+                        [
+                            '@babel/preset-env',
+                            {
+                                useBuiltIns: 'entry',
+                                corejs: '2',
+                            },
+                        ],
                     ],
                     plugins: [
                         '@babel/plugin-proposal-class-properties',


### PR DESCRIPTION
## Overview

- run npm audit fix to fix vulnerabilities
- add corejs-2 to polyfill development and staging demo sites so they'll work in IE11
- continue not using corejs-2 for production library builds, as the polyfills will be applied in host applications

Connects #86 

### Demo

![Screen Shot 2019-05-17 at 11 22 19 AM](https://user-images.githubusercontent.com/4165523/57938360-0d97f200-7896-11e9-81bf-d61d46fb6a91.png)

## Testing Instructions

- visit the Netlify PR build site in IE11 and verify that it works
