### PR TITLE
Prevent search button from disappearing in IE11

### DIFF
--- a/src/sass/02_tools/_mixins.scss
+++ b/src/sass/02_tools/_mixins.scss
@@ -44,7 +44,7 @@
 }
 
 @mixin restore {
-    display: initial;
+    display: inline;
 }
 
 @mixin responsive($breakpoint : $pwdub-breakpoint-mobile) {


### PR DESCRIPTION
## Overview

Per #87 the search input appeared not to work in IE11. I investigated and it turned out that the search did work on pressing enter but the button was disappearing when the search text input got blurred, apparently because IE11 won't accept a `display: initial` CSS property. 

To fix it I replaced `display: initial` with `display: inline`. I checked and this seems to have no regressions in IE11 or Firefox, but it may be that there's a better way to fix this.

Connects #87 

## Testing Instructions

- check out the Netlify staging site in Chrome, FF, and IE11 and verify that the search button does not disappear when you try to click it
- verify that this is an acceptable solution
